### PR TITLE
fix URLs: `s/robinl\.github\.io\/robinlinacre/robinl.github.io/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-The source code for https://robinl.github.io/robinlinacre/  See [here](https://robinl.github.io/robinlinacre/interactive_blogging) for a post about how the website works.
+The source code for https://robinl.github.io  See [here](https://robinl.github.io/interactive_blogging) for a post about how the website works.


### PR DESCRIPTION
There seem to be other broken references to robinl.github.io/robinlinacre/… outside this repo, e.g. in [the "interactive_blogging" observable](https://observablehq.com/@robinl/interactive-blogging-with-observable-notebooks-and-gatsb)

Very cool site though! Loved the [Parquet](https://www.robinlinacre.com/parquet_api/) and [Arrow](https://www.robinlinacre.com/demystifying_arrow/) posts.