### PR TITLE
Fix typo in activate definition

### DIFF
--- a/src/definitions_markdown/activate.md
+++ b/src/definitions_markdown/activate.md
@@ -4,7 +4,7 @@ term: 'activate'
 
 A scenario is 'activated' when it is conditions are met for the pairwise record comparison at hand.
 
-For example, consider the pariwise comparison of first name of 'Robyn' vs 'Robin'.
+For example, consider the pairwise comparison of first name of 'Robyn' vs 'Robin'.
 
 The following scenarios may be defined for the `first_name` column:
 


### PR DESCRIPTION
## Summary
- fix a spelling mistake in the activate definition

## Testing
- `grep -n pariwise -r src/definitions_markdown`


------
https://chatgpt.com/codex/tasks/task_e_683f6d8fe218832d9ef2051e82a10065