### PR TITLE
Fix PostList filter categories

### DIFF
--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -87,7 +87,7 @@ const PostList = () => {
         ...new Set(
             allPosts.map(post => post.frontmatter.post_category || 'other')
         ),
-    ];
+    ].filter(category => headerOrder.includes(category));
 
     const sortedCategories = allCategories.sort((a, b) => {
         const indexA = headerOrder.indexOf(a);

--- a/src/mdx/structured_vibe_coding.mdx
+++ b/src/mdx/structured_vibe_coding.mdx
@@ -2,7 +2,7 @@
 title: "Putting Scaffolding Around Vibe Coding to Build More Complex Apps"
 description: "How to work past the limits of LLMs to build more complex apps"
 post_date: "2025-05-18"
-post_category: "LLMs"
+post_category: "data"
 code_url: "https://github.com/RobinL/robinl.github.io/blob/dev/src/mdx/structured_vibe_coding.mdx"
 ---
 


### PR DESCRIPTION
## Summary
- filter categories only to ones in `headerOrder`
- assign `structured_vibe_coding.mdx` to the `data` category so unused `LLMs` tag disappears

## Testing
- `npx gatsby build` *(fails: local build command unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_683f6dfc1e20832d99995c7837d16b42