### PR TITLE
Fix DuckLake podcast frontmatter

### DIFF
--- a/src/links_quotes_markdown/20250527_ducklake_podcast.md
+++ b/src/links_quotes_markdown/20250527_ducklake_podcast.md
@@ -1,5 +1,5 @@
 ---
-type: "podcast"
+type: "link"
 title: "Introducing DuckLake"
 url: "https://www.youtube.com/watch?v=zeonmOO9jm4"
 date: "2025-05-27"


### PR DESCRIPTION
## Summary
- fix frontmatter type for DuckLake podcast link

## Testing
- `npm run` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_683f773bb0a8832d865e16167dc179ff