### PR TITLE
Add transcript link for DuckLake intro

### DIFF
--- a/src/links_quotes_markdown/20250527_ducklake_podcast.md
+++ b/src/links_quotes_markdown/20250527_ducklake_podcast.md
@@ -6,4 +6,4 @@ date: "2025-05-27"
 tags: ["duckdb"]
 ---
 
-A podcast introducing the DuckLake project with Hannes Mühleisen and Mark Raasveldt.
+A podcast introducing the DuckLake project with Hannes Mühleisen and Mark Raasveldt. Transcript [here](https://gist.github.com/RobinL/daff2396e32346791c7f08a1758b2de7).


### PR DESCRIPTION
## Summary
- add transcript reference for DuckLake introduction podcast link

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683ff923b944832d9a6bb6ab1f9e120b