### PR TITLE
Add Waymo foundation model podcast link

### DIFF
--- a/src/links_quotes_markdown/20250331_waymo_foundation_model.md
+++ b/src/links_quotes_markdown/20250331_waymo_foundation_model.md
@@ -1,0 +1,9 @@
+---
+type: "podcast"
+title: "Waymo’s Foundation Model for Autonomous Driving with Drago Anguelov"
+url: "https://twimlai.com/podcast/twimlai/waymos-foundation-model-for-autonomous-driving/"
+date: "2025-03-31"
+tags: ["autonomous driving"]
+---
+
+Interesting discussion of how generative AI is impacting self-driving.


### PR DESCRIPTION
## Summary
- add TWIML AI Podcast link about Waymo's foundation model for autonomous driving

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb2b76dc832da629176b13adbea4