### PR TITLE
Add DuckLake video link post

### DIFF
--- a/src/links_quotes_markdown/20250605_understanding_ducklake.md
+++ b/src/links_quotes_markdown/20250605_understanding_ducklake.md
@@ -1,0 +1,9 @@
+---
+type: "link"
+title: "Understanding DuckLake: A Table Format with a Modern Architecture"
+url: "https://www.youtube.com/watch?v=hrTjvvwhHEQ"
+date: "2025-06-05"
+tags: ["duckdb"]
+---
+
+Transcript [here](https://gist.github.com/RobinL/26147dbe5500c6ea63763b2516d9dcc0).


### PR DESCRIPTION
## Summary
- add link post for "Understanding DuckLake" video with transcript link

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb8dbe48832d8ab307ae7a3a0108