### PR TITLE
Add quote from Drew Breunig on LLM context failures

### DIFF
--- a/src/links_quotes_markdown/20250622_drew_breunig_how_contexts_fail.md
+++ b/src/links_quotes_markdown/20250622_drew_breunig_how_contexts_fail.md
@@ -1,0 +1,11 @@
+---
+type: "quote"
+author: "Drew Breunig"
+date: "2025-06-22"
+url: "https://www.dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html"
+tags: ["LLMs"]
+---
+
+> Sometimes, you might sit down and type paragraphs into ChatGPT or Claude before you hit enter, considering every necessary detail. Other times, you might start with a simple prompt, then add further details when the chatbot’s answer isn’t satisfactory
+>
+> We find that LLMs often make assumptions in early turns and prematurely attempt to generate final solutions, on which they overly rely. In simpler terms, we discover that when LLMs take a wrong turn in a conversation, they get lost and do not recover.


### PR DESCRIPTION
## Summary
- add new quote post referencing Drew Breunig's article about LLM context failures

## Testing
- `npx gatsby build` *(fails: needs gatsby install)*

------
https://chatgpt.com/codex/tasks/task_e_6863f192e134832da40e146f64d03e0c