### PR TITLE
Add quote from Sholto Douglas on AGI progress

### DIFF
--- a/src/links_quotes_markdown/20251002_sholto_douglas_ai_plateau_myth.md
+++ b/src/links_quotes_markdown/20251002_sholto_douglas_ai_plateau_myth.md
@@ -1,0 +1,20 @@
+---
+type: "quote"
+author: "Sholto Douglas"
+date: "2025-10-02"
+url: "https://youtu.be/FQy4YMYFLsI?si=hOZRPpMXiKuaPRlR"
+tags: ["AGI", "LLMs"]
+---
+
+> Matt Turck: What do you make of the “Are We on Track to AGI?” debate — the counter-thesis from people like Rich Sutton or Yann LeCun, who argue that a different approach is needed, or that it should be reinforcement learning only?
+>
+> Sholto Douglas:
+> I think it’s true that our models don’t learn anywhere near as efficiently as humans do. They take a thousand lifetimes to learn — but that’s fine, because they can live those thousand lifetimes in simulation or by doing work across a thousand firms, and so on.
+>
+> I’d separate two arguments here. One is architectural — that transformers are insufficient. I don’t think that’s true. We haven’t yet found anything that transformers can’t model given enough data and compute.
+>
+> Reinforcement learning as an objective is a powerful idea. Rich Sutton is actually a big fan of RL as an objective; he just thinks we’re encoding too many priors through pre-training and similar methods, which leads to an inadequate representation of the world.
+>
+> So far, the evidence suggests our current methods haven’t yet encountered a domain that’s intractable with enough effort. The only thing that would make me change my mind would be if there were a problem domain where, despite heavy effort, benchmarks simply didn’t move for a long time. That would suggest a fundamental limitation.
+>
+> But instead, what I constantly see is that every time we define a benchmark that measures something we care about, progress along that benchmark is incredibly rapid. Anything we can measure seems to be improving very quickly.


### PR DESCRIPTION
## Summary
- add a new quote entry for the 2 October 2025 discussion with Sholto Douglas on the MAD Podcast
- include the full exchange and source link to the YouTube recording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b5bae340832db5f0fd120279300b