### PR TITLE
Add microblog: LLMs — semantics vs coding and tool use

### DIFF
--- a/src/microblog_md/20260414_llm_semantics_vs_tool_use.md
+++ b/src/microblog_md/20260414_llm_semantics_vs_tool_use.md
@@ -1,0 +1,9 @@
+---
+title: "LLMs: semantics vs coding and tool use"
+date: "2026-04-14"
+tags: ["AI", "LLMs"]
+---
+
+As capabilities have improved, I am increasingly sceptical of describing LLMs as a “calculator for words,” and of the idea that they [excel at semantics](https://www.complexsystemspodcast.com/episodes/ai-alignment-with-emmett-shear/#:~:text=That%20an%20LLM%20gets%20is%20not%20spatial%2C%20it%20is%20semantic.).
+
+The rate of improvement in these areas seems extremely modest compared with things like coding and tool use.


### PR DESCRIPTION
### Motivation
- Capture a short microblog noting scepticism about describing LLMs as a “calculator for words” and the claim that they inherently "excel at semantics", and contrast semantic progress with faster gains in coding and tool use.

### Description
- Add `src/microblog_md/20260414_llm_semantics_vs_tool_use.md` containing frontmatter (`title`, `date`, `tags`) and two brief paragraphs including a link to the referenced podcast segment.

### Testing
- Ran `git diff --check` and `git diff --cached --check`, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6e30fb5c832d8e10a188df9234fd)