### PR TITLE
Add links/quotes post for jdw64 HN comment on tacit knowledge

### DIFF
--- a/src/content/links-quotes/20260426_jdw64_hn_tacit_knowledge.md
+++ b/src/content/links-quotes/20260426_jdw64_hn_tacit_knowledge.md
@@ -1,0 +1,17 @@
+---
+type: "quote"
+author: "jdw64"
+date: "2026-04-26"
+url: "https://news.ycombinator.com/item?id=47908165"
+tags: ["ai", "management", "knowledge"]
+---
+
+> The real issue, in my view, is not AI itself.
+>
+> The problem is a management pattern: removing people and organizational slack because they don’t generate immediate profit, and then expecting the knowledge to still be there when it’s needed.
+>
+> Short-term cost cutting leads to less junior hiring, and removes the slack that experienced engineers need in order to teach. As a result, tacit knowledge stops being transferred.
+>
+> What remains is documentation and automation.
+>
+> But documentation is not the same as field experience. Automation is not the same as judgment. Without people who have actually worked with the system, you end up with a loss of tacit knowledge—and eventually, declining productivity.


### PR DESCRIPTION
### Motivation
- Capture and surface a notable Hacker News comment about tacit knowledge and management decisions as a short `links-quotes` entry for the site.

### Description
- Add `src/content/links-quotes/20260426_jdw64_hn_tacit_knowledge.md` containing frontmatter (`type: "quote"`, `author: "jdw64"`, `date: "2026-04-26"`, `url`, and `tags`) and the provided comment as a blockquote.

### Testing
- No site build or automated tests were run for this content-only change; the file contents were inspected with `nl -ba src/content/links-quotes/20260426_jdw64_hn_tacit_knowledge.md` to verify the frontmatter and quote text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2d16d634832db1f739d6fe066919)