### PR TITLE
Add microblog post: "Simpler software without bullshit"

### DIFF
--- a/src/content/microblog/20260507_simpler_software_without_bullshit.md
+++ b/src/content/microblog/20260507_simpler_software_without_bullshit.md
@@ -1,0 +1,15 @@
+---
+title: "Simpler software without bullshit"
+date: "2026-05-07"
+tags: ["AI", "Coding", "Software"]
+---
+
+I'm increasingly convinced that Karpathy's “code is ephemeral now and libraries are over” and Ryan Dahl's [“i expect almost all software is about to be rewritten from scratch”](https://x.com/rough__sea/status/2051878481601187848?s=20) are not complete hyperbole.
+
+A big reason ChatGPT is better than Google Search is that it can give you a plaintext answer without ads, paywalls, clickbait, and other internet garbage.
+
+There's a parallel with SaaS and browser-based software. I hate monthly subscriptions, and often the software itself is plagued by perverse incentives: companies want to sustain engagement to maintain that monthly fee.
+
+I'm already seeing Codex produce simple software better than existing paid or free options, for example [Countries Quiz](https://rupertlinacre.com/country_quiz/) and [Letterpaths](https://www.robinlinacre.com/letterpaths/).
+
+As models get better, the amount of software falling into this category will increase. I'm optimistic that in the not-too-distant future we'll be using better, faster, simpler software with much less bullshit. Because if nothing else, if it doesn't exist, I can build it myself.


### PR DESCRIPTION
### Motivation
- Capture a short microblog argument that AI (Codex/ChatGPT) is driving a shift toward simpler, faster software and away from subscription/browser-first SaaS, referencing Karpathy and Ryan Dahl.

### Description
- Add a new microblog markdown at `src/content/microblog/20260507_simpler_software_without_bullshit.md` with frontmatter and content linking to Ryan Dahl, Countries Quiz, and Letterpaths.

### Testing
- Ran `pnpm build` which completed successfully and verified the new post appears on the microblog index using `curl -s http://127.0.0.1:4321/microblog/ | rg -n "Simpler software|Karpathy|Ryan Dahl" -C 2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce374a538832d9b3e2d2900b9a9ff)