### PR TITLE
Add "Token crunch" microblog (2026-05-16)

### DIFF
--- a/src/content/microblog/20260516_token_crunch.md
+++ b/src/content/microblog/20260516_token_crunch.md
@@ -1,0 +1,9 @@
+---
+title: "Token crunch"
+date: "2026-05-16"
+tags: ["LLMs", "Workflows"]
+---
+
+With the withdrawal of premium requests in VS Code Copilot, I think there's going to be a difficult period where people run out of their monthly allowances extremely quickly. Very difficult to manage in large orgs, since individuals could easily be legitimately using £100s in tokens (in a value-for-money/time-saved sense), whilst others could be spending similar amounts much less effectively. Very difficult to give different budgets to different teams, so hard to know how it'll pan out.
+
+See also: [this Hacker News comment](https://news.ycombinator.com/item?id=48157711), which says a FAANG gives engineers $300/day and encourages them to use it.


### PR DESCRIPTION
### Motivation
- Add a short microblog post about token allowance pain following the withdrawal of premium requests in VS Code Copilot and the resulting org-level budgeting challenges.

### Description
- Create `src/content/microblog/20260516_token_crunch.md` with frontmatter (`title`, `date`, `tags`) and the post content including a Hacker News reference to a FAANG $300/day AI budget comment.

### Testing
- Ran `pnpm build` and the site built successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084b697dc4832d96f12717b5f7f796)