### PR TITLE
Add rakyll coding agents quote post

### DIFF
--- a/src/content/links-quotes/20260708_rakyll_coding_agents_social_overhead.md
+++ b/src/content/links-quotes/20260708_rakyll_coding_agents_social_overhead.md
@@ -1,0 +1,17 @@
+---
+type: "quote"
+author: "Jaana Dogan (@rakyll)"
+date: "2026-07-08"
+url: "https://x.com/rakyll/status/2074673443975700653?s=20"
+tags: ["AI", "management"]
+---
+
+> For most of my life, the real cost of building something that solves a hard problem inside a large organization was not always about typing. It was often inventing it in the first place, then coordination. Execution overhead was almost always dwarfed by social overhead. You spent your best energy earning permission to start, and then had to do it again and again just to continue. Coding agents remove this traditional permission system. They benefit some while simultaneously creating unmanageable chaos for others.
+>
+> Coding agents collapse the execution cost so aggressively that the bottleneck moves. An individual can now go from intent to a working prototype without assembling a group first. This reduces the burden to show something, but also enables new levels of cookie licking.
+>
+> It also creates chaos by making it too easy to fork an idea or a project when no one is in charge to make broad decisions for organizations. This puts traditional organizations in a tough spot.
+>
+> I've seen projects that spend 3-5x more energy in alignment and exec reviews than engineering. With coding agents, we exponentially reduce the time spent in engineering and increase the effort required to align vision, strategy, timelines, etc.
+>
+> Coding agents have a deep impact on engineering in general, but the way they challenge traditional org charts and ownership is much bigger. With this new kind of forkability, there is no real ownership unless it's enforced top-down, which is often bad.


### PR DESCRIPTION
## Summary
- add a new quotes-links entry for Jaana Dogan's July 8, 2026 thread on coding agents
- flatten the thread into a single readable quote card with one source link
- keep the change scoped to content only

## Validation
- `CI=true pnpm build`
