### PR TITLE
Add microblog post on LLM agents in cloud VMs

### DIFF
--- a/src/content/microblog/20260804_agents_cloud_vms.md
+++ b/src/content/microblog/20260804_agents_cloud_vms.md
@@ -1,0 +1,13 @@
+---
+title: "LLM agents on cloud VMs"
+date: "2026-08-04"
+tags: ["LLMs", "Agents", "Coding"]
+---
+
+The direction of travel seems to be LLM agents moving to cloud VMs.
+
+Local machines have a lot of downsides: managing multiple worktrees and checkouts for parallel agents, security concerns, and having to leave the machine on while an agent grinds away.
+
+We're already seeing a version of this in ChatGPT work: according to [Max Jendrall](https://x.com/maxjendrall/status/2079874049455309023?s=20), Plus users get 9 CPU cores and 15 GB RAM. I would rather do much of my Codex work in that environment too, with each chat backed by a different VM.
+
+See also [Tibo Sottiaux](https://x.com/thsottiaux/status/2084483765158719542?s=20).


### PR DESCRIPTION
## Summary

- add the 4 August 2026 microblog post on the move towards cloud VM-backed LLM agents
- cover local worktree, security, and always-on-machine trade-offs
- retain the supplied Max Jendrall and Tibo Sottiaux links

## Validation

- `pnpm install --frozen-lockfile`
- `npm run build`
- `git diff --check`

`npm run check` runs but currently fails on existing Astro virtual-module and missing asset imports outside this change.