### PR TITLE
Add taste and judgement link

### DIFF
--- a/src/content/links-quotes/20260807_taste_is_all_thats_left.md
+++ b/src/content/links-quotes/20260807_taste_is_all_thats_left.md
@@ -1,0 +1,9 @@
+---
+type: "link"
+title: "Taste is all that's left"
+url: "https://notashelf.dev/posts/taste-is-all-thats-left"
+date: "2026-08-07"
+tags: []
+---
+
+Judgement is more expensive than implementation though!  Especially in large bureacracies


### PR DESCRIPTION
## What changed

Added a dated link post for “Taste is all that's left” with commentary about judgement and implementation costs in large bureaucracies.

## Impact

The new entry will appear in the blog's links/quotes collection and its generated feeds and pages.

## Validation

- `npm run build`
- `git diff --cached --check`